### PR TITLE
Work on https://github.com/Islandora-CLAW/CLAW/issues/1153.

### DIFF
--- a/config/install/migrate_plus.migration.node.yml
+++ b/config/install/migrate_plus.migration.node.yml
@@ -24,6 +24,9 @@ source:
     # We're tagging our nodes as Images
     model: Image 
 
+    # We're tagging our nodes as Images
+    resource_type: Image
+
     # The 'photographer' MARC relator
     relator: 'relators:pht' 
 
@@ -56,6 +59,14 @@ process:
     value_key: name 
     bundle_key: vid
     bundle: islandora_models 
+
+  field_resource_type:
+    plugin: entity_lookup
+    source: constants/resource_type
+    entity_type: taxonomy_term
+    value_key: name
+    bundle_key: vid
+    bundle: resource_types
 
   # Split up our pipe-delimited string of
   # subjects, and generate terms for each.


### PR DESCRIPTION
Github issue: https://github.com/Islandora-CLAW/CLAW/issues/1153

# What this PR does

Adds population of the node's field_resource_type with the value 'Image'.

# How to test

1. Run this migration using the dev branch using `drush migrate:import --group migrate_islandora_csv --userid=1`. Imported nodes' Resource Type field will not be populated.
1. Roll back that migration using `drush -y mr --group migrate_islandora_csv`.
1. Check out this branch.
1. Reload the migration configuration using `drush -y fim migrate_islandora_csv`.
1. Rerun the migration using `drush migrate:import --group migrate_islandora_csv --userid=1`.
1. The imported nodes' Resource Type field will not be populated with 'Image'.