### PR TITLE
Another approach to doing this.

### DIFF
--- a/config/install/migrate_plus.migration.node.yml
+++ b/config/install/migrate_plus.migration.node.yml
@@ -48,7 +48,8 @@ process:
   # Dates are EDTF strings
   field_edtf_date: issued
     
-  # Make the object an 'Image'
+  # Make the object an 'Image' (in the Model field).
+  # This value is hard-coded in this configuration.
   field_model:
     plugin: entity_lookup
     source: constants/model
@@ -56,6 +57,16 @@ process:
     value_key: name 
     bundle_key: vid
     bundle: islandora_models 
+
+  # Also populate the "Resrouce type" field from string
+  # values in the 'resource_type' column in the CSV file.
+  field_resource_type:
+    plugin: entity_generate
+    source: resource_type
+    entity_type: taxonomy_term
+    value_key: name
+    bundle_key: vid
+    bundle: resource_types
 
   # Split up our pipe-delimited string of
   # subjects, and generate terms for each.

--- a/data/migration.csv
+++ b/data/migration.csv
@@ -1,6 +1,6 @@
-file,title,subtitle,description,issued,subject,photographer
-/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/Nails Nails Nails.jpg,Nails Nails Nails,,A sign pointing towards a nail salon.,2018-01-01,Neon signs|Night,Clem Onojeghuo
-/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/Free Smells.jpg,Free Smells,We're givin' 'em away,A sign on a restaurant front advertising free smells,2018-02-01,Neon signs|Night|Funny,The Collab
-/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/Nothing to See Here.jpg,Nothing To See Here,Move Along People,A sign above a building that says "Nothing to see here",2018-03-01,Neon signs|Night,Argelis Rebolledo
-/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/Call For Champagne.jpg,Call For Champagne,,A neon sign above some rotary telephones telling customers to call for champagne.,2018-04-01,Drinking|Neon signs,Design Doctor
-/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/This Must Be The Place.jpg,This Must Be The Place,,A neon sign on a multi-colored wall that reads "This Must Be The Place",2018-05-01,Neon signs,Tim Mossholder
+file,title,subtitle,description,issued,subject,photographer,resource_type
+/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/Nails Nails Nails.jpg,Nails Nails Nails,,A sign pointing towards a nail salon.,2018-01-01,Neon signs|Night,Clem Onojeghuo,Image
+/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/Free Smells.jpg,Free Smells,We're givin' 'em away,A sign on a restaurant front advertising free smells,2018-02-01,Neon signs|Night|Funny,The Collab,Image
+/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/Nothing to See Here.jpg,Nothing To See Here,Move Along People,A sign above a building that says "Nothing to see here",2018-03-01,Neon signs|Night,Argelis Rebolledo,Image
+/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/Call For Champagne.jpg,Call For Champagne,,A neon sign above some rotary telephones telling customers to call for champagne.,2018-04-01,Drinking|Neon signs,Design Doctor,Image
+/var/www/html/drupal/web/modules/contrib/migrate_islandora_csv/data/images/This Must Be The Place.jpg,This Must Be The Place,,A neon sign on a multi-colored wall that reads "This Must Be The Place",2018-05-01,Neon signs,Tim Mossholder,Image


### PR DESCRIPTION
Github issue: https://github.com/Islandora-CLAW/CLAW/issues/1153

# What this PR does

Adds population of the node's field_resource_type with the value 'Image'. Unlike #15, takes term from the CSV file.

# How to test

1. Run this migration using the dev branch using `drush migrate:import --group migrate_islandora_csv --userid=1`. Imported nodes' Resource Type field will not be populated.
1. Roll back that migration using `drush -y mr --group migrate_islandora_csv`.
1. Check out this branch.
1. Reload the migration configuration using `drush -y fim migrate_islandora_csv`.
1. Rerun the migration using `drush migrate:import --group migrate_islandora_csv --userid=1`.
1. The imported nodes' Resource Type field will not be populated with 'Image'.