### PR TITLE
Update README.md to de-CLAW and fix some broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ __A note on using Features__: This process makes heavy use of Features, which is
 
 The Migrate API is the main way to ingest batches of data into Drupal (and because Islandora 8 is Drupal, into Islandora). The Migrate module only provides the framework, it's up to you to create the rules that take data from a _source_, through a _process_ (i.e. a mapping) to a _destination_. A set of these rules is called a "migration". It has to be set up (in code) and then it has to be run.
 
-Once a migration has been run, it will have created (or updated) a bunch of Drupal entities of one type - whether that's taxonomy terms, nodes, files, etc. Since an Islandora Object in Islandora 8 is made up of several different Drupal entities that refer to each other, it's going to take multiple migrations to create an Islandora object, and it's important to perform these migrations in a sensible order.
+Once a migration has been run, it will have created (or updated) a bunch of Drupal entities of one type - whether that's taxonomy terms, nodes, files, etc. Since an Object in Islandora 8 is made up of several different Drupal entities that refer to each other, it's going to take multiple migrations to create an Islandora object, and it's important to perform these migrations in a sensible order.
 
 A basic Islandora object is at minimum:
 - a file, which holds the actual binary contents of an item


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1082

# What does this Pull Request do?

Replaces references to Islandora CLAW in readme files with "Islandora 8." Does not go any deeper into the code to hunt down CLAWs, and leaves alone "CLAW" where it's still necessary to point to other repos. 

Also replaces a few references to since-renamed tools and fixes broken links.

# What's new?

Islandora CLAW -> Islandora 8 in migrate_islandora_csv readmes.

# How should this be tested?

Review and make sure I got'em all. 

# Additional Notes:

One PR of many.

# Interested parties
@Islandora-CLAW/committers